### PR TITLE
Upgrade to 1.17 and create new subcommands

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,32 +6,38 @@
 
     <groupId>me.emiljimenez21</groupId>
     <artifactId>virtualshop</artifactId>
-    <version>2.4</version>
+    <version>2.7</version>
     <packaging>jar</packaging>
 
     <name>VirtualShop</name>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>16</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <build>
         <defaultGoal>clean package</defaultGoal>
+        
         <plugins>
+                    <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.0</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.8.1</version>
                 <configuration>
-                <source>1.8</source>
-                <target>1.8</target>
+                <source>16</source>
+                <target>16</target>
             </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -39,7 +45,22 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                                      <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
+                        <resource>META-INF/services/java.sql.Driver</resource>
+                        </transformer>
+                    </transformers>
                             <createDependencyReducedPom>false</createDependencyReducedPom>
+                    <artifactSet>
+                    <includes>
+                    <include> com.github.kangarko:Foundation </include>
+               
+                    </includes>
+
+                    </artifactSet>
+
+                                             
+     
                         </configuration>
                     </execution>
                 </executions>
@@ -54,10 +75,10 @@
     </build>
 
     <repositories>
-        <repository>
-            <id>destroystokyo-repo</id>
-            <url>https://repo.destroystokyo.com/repository/maven-public/</url>
-        </repository>
+<repository>
+    <id>papermc</id>
+    <url>https://papermc.io/repo/repository/maven-public/</url>
+</repository>
         <repository>
             <id>sonatype</id>
             <url>https://oss.sonatype.org/content/groups/public/</url>
@@ -69,16 +90,21 @@
     </repositories>
 
     <dependencies>
-        <dependency>
-            <groupId>com.destroystokyo.paper</groupId>
-            <artifactId>paper-api</artifactId>
-            <version>1.15.2-R0.1-SNAPSHOT</version>
-            <scope>provided</scope>
+    <dependency>
+        <groupId>io.papermc.paper</groupId>
+        <artifactId>paper-api</artifactId>
+        <version>1.17.1-R0.1-SNAPSHOT</version>
+        <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.xerial</groupId>
+        <artifactId>sqlite-jdbc</artifactId>
+        <version>LATEST</version>
         </dependency>
         <dependency>
             <groupId>com.github.kangarko</groupId>
             <artifactId>Foundation</artifactId>
-            <version>5.3.8</version>
+            <version>LATEST</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/me/emiljimenez21/virtualshop/Virtualshop.java
+++ b/src/main/java/me/emiljimenez21/virtualshop/Virtualshop.java
@@ -19,6 +19,7 @@ import org.mineacademy.fo.settings.YamlStaticConfig;
 
 import java.util.Arrays;
 import java.util.List;
+import lombok.Getter;
 
 public class Virtualshop extends SimplePlugin {
     private static Reporting report;
@@ -28,7 +29,8 @@ public class Virtualshop extends SimplePlugin {
     private static JobManager jobManager = null;
     private static Economy economy = null;
     private static Updater updater = null;
-
+	@Getter
+	private final VirtualshopCommandGroup mainCommand = new VirtualshopCommandGroup();
     @Override
     protected void onPluginStart() {
         jobManager = new JobManager();
@@ -82,15 +84,15 @@ public class Virtualshop extends SimplePlugin {
         // Register Event Listeners
         registerEvents(new PlayerListener());
 
-        // Register commands
-        registerCommand(new Help("shop"));
-        registerCommand(new Sell("sell"));
-        registerCommand(new Buy( "buy"));
-        registerCommand(new Find("find"));
-        registerCommand(new Transactions("sales"));
-        registerCommand(new Cancel("cancel"));
-        registerCommand(new Stock("stock"));
-
+        // // Register commands
+        // registerCommand(new Help("shop"));
+        // registerCommand(new Sell("sell"));
+        // registerCommand(new Buy( "buy"));
+        // registerCommand(new Find("find"));
+        // registerCommand(new Transactions("sales"));
+        // registerCommand(new Cancel("cancel"));
+        // registerCommand(new Stock("stock"));
+  
         // Async player load
         jobManager.runAsyncJob(new SyncOnlinePlayers());
 

--- a/src/main/java/me/emiljimenez21/virtualshop/Virtualshop.java
+++ b/src/main/java/me/emiljimenez21/virtualshop/Virtualshop.java
@@ -95,7 +95,7 @@ public class Virtualshop extends SimplePlugin {
         jobManager.runAsyncJob(new SyncOnlinePlayers());
 
         // Check for updates hourly
-        jobManager.runAsyncRepetitiveJob(new CheckForUpdates(), 0,3600);
+       // jobManager.runAsyncRepetitiveJob(new CheckForUpdates(), 0,3600);
 
         // Remove players hourly
         jobManager.runAsyncRepetitiveJob(new HourlyPlayerCachePurge(), 3600, 3600);

--- a/src/main/java/me/emiljimenez21/virtualshop/VirtualshopCommandGroup.java
+++ b/src/main/java/me/emiljimenez21/virtualshop/VirtualshopCommandGroup.java
@@ -1,0 +1,24 @@
+package me.emiljimenez21.virtualshop;
+import me.emiljimenez21.virtualshop.commands.*;
+import org.mineacademy.fo.command.ReloadCommand;
+import org.mineacademy.fo.command.SimpleCommandGroup;
+public final class VirtualshopCommandGroup extends SimpleCommandGroup {
+	@Override
+	protected void registerSubcommands() {
+		registerHelpLine(" &6&lPlayer Commands");
+
+        registerSubcommand(new Help("shop"));
+        registerSubcommand(new Sell("sell"));
+        registerSubcommand(new Buy( "buy"));
+        registerSubcommand(new Find("find"));
+        registerSubcommand(new Transactions("sales"));
+        registerSubcommand(new Cancel("cancel"));
+        registerSubcommand(new Stock("stock"));
+
+
+        registerHelpLine(" ", " &6&lAdmin commands");
+
+        registerSubcommand(new ReloadCommand());
+
+	}
+}

--- a/src/main/java/me/emiljimenez21/virtualshop/commands/Find.java
+++ b/src/main/java/me/emiljimenez21/virtualshop/commands/Find.java
@@ -76,7 +76,7 @@ public class Find extends ShopCommand {
             page = 1;
         }
 
-        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "STOCK " + ChatColor.BOLD + ChatColor.LIGHT_PURPLE + " >> " + Messages.formatItem(item.getName().toUpperCase() + ChatColor.DARK_GRAY), '=', ChatColor.DARK_GRAY));
+        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "STOCK " + ChatColor.BOLD + ChatColor.LIGHT_PURPLE + " >> " + Messages.formatItem(item.getName().toUpperCase() + ChatColor.DARK_GRAY), '='));
         for(int i = start; i < (start + page_size); i++) {
             try {
                 Common.tell(sender, ChatUtil.center(Messages.STOCK_LISTING
@@ -90,6 +90,6 @@ public class Find extends ShopCommand {
                 break;
             }
         }
-        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "PAGE " + ChatColor.YELLOW + page + ChatColor.GRAY + " OF " + ChatColor.YELLOW + pages + ChatColor.DARK_GRAY, '=', ChatColor.DARK_GRAY));
+        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "PAGE " + ChatColor.YELLOW + page + ChatColor.GRAY + " OF " + ChatColor.YELLOW + pages + ChatColor.DARK_GRAY, '='));
     }
 }

--- a/src/main/java/me/emiljimenez21/virtualshop/commands/Help.java
+++ b/src/main/java/me/emiljimenez21/virtualshop/commands/Help.java
@@ -20,7 +20,7 @@ public class Help extends ShopCommand {
         super.onCommand();
         Virtualshop.getAnalytics().incrementShop();
 
-        Common.tell(sender, ChatUtil.center( ChatColor.LIGHT_PURPLE + "" + ChatColor.BOLD + "VirtualShop", '=', ChatColor.DARK_GRAY));
+        Common.tell(sender, ChatUtil.center( ChatColor.LIGHT_PURPLE + "" + ChatColor.BOLD + "VirtualShop", '='));
 
         if(sender.hasPermission("virtualshop.find")) {
             Common.tell(sender, ChatUtil.center(Messages.BASE_COLOR + Messages.HELP_FIND

--- a/src/main/java/me/emiljimenez21/virtualshop/commands/ShopCommand.java
+++ b/src/main/java/me/emiljimenez21/virtualshop/commands/ShopCommand.java
@@ -4,11 +4,11 @@ import me.emiljimenez21.virtualshop.managers.PlayerManager;
 import me.emiljimenez21.virtualshop.objects.ShopItem;
 import me.emiljimenez21.virtualshop.objects.ShopUser;
 import me.emiljimenez21.virtualshop.settings.Messages;
-import org.mineacademy.fo.command.SimpleCommand;
+import org.mineacademy.fo.command.SimpleSubCommand;
 
 import java.util.concurrent.TimeUnit;
 
-public abstract class ShopCommand extends SimpleCommand {
+public abstract class ShopCommand extends  SimpleSubCommand  {
     protected ShopUser user;
     protected ShopItem item = null;
     protected Integer amount = null;

--- a/src/main/java/me/emiljimenez21/virtualshop/commands/Stock.java
+++ b/src/main/java/me/emiljimenez21/virtualshop/commands/Stock.java
@@ -114,7 +114,7 @@ public class Stock extends ShopCommand {
             page = 1;
         }
 
-        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "STOCK " + ChatColor.BOLD + ChatColor.LIGHT_PURPLE + " >> " + Messages.formatPlayer(player.name), '=', ChatColor.DARK_GRAY));
+        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "STOCK " + ChatColor.BOLD + ChatColor.LIGHT_PURPLE + " >> " + Messages.formatPlayer(player.name), '='));
         for(int i = start; i < (start + page_size); i++) {
             try {
                 Common.tell(sender, ChatUtil.center(Messages.STOCK_LISTING
@@ -128,7 +128,7 @@ public class Stock extends ShopCommand {
                 break;
             }
         }
-        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "PAGE " + ChatColor.YELLOW + page + ChatColor.GRAY + " OF " + ChatColor.YELLOW + pages + ChatColor.DARK_GRAY, '=', ChatColor.DARK_GRAY));
+        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "PAGE " + ChatColor.YELLOW + page + ChatColor.GRAY + " OF " + ChatColor.YELLOW + pages + ChatColor.DARK_GRAY, '='));
 
     }
 }

--- a/src/main/java/me/emiljimenez21/virtualshop/commands/Transactions.java
+++ b/src/main/java/me/emiljimenez21/virtualshop/commands/Transactions.java
@@ -115,7 +115,7 @@ public class Transactions extends ShopCommand {
             page = 1;
         }
 
-        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "TRANSACTIONS " + ChatColor.BOLD + ChatColor.LIGHT_PURPLE + " >> " + Messages.formatPlayer(player.name), '=', ChatColor.DARK_GRAY));
+        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "TRANSACTIONS " + ChatColor.BOLD + ChatColor.LIGHT_PURPLE + " >> " + Messages.formatPlayer(player.name), '='));
         for(int i = start; i < (start + page_size); i++) {
             try {
                 String seller = transactions.get(i).seller.name.equalsIgnoreCase(sender.getName()) ? "I" : transactions.get(i).seller.name;
@@ -132,7 +132,7 @@ public class Transactions extends ShopCommand {
                 break;
             }
         }
-        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "PAGE " + ChatColor.YELLOW + page + ChatColor.GRAY + " OF " + ChatColor.YELLOW + pages + ChatColor.DARK_GRAY, '=', ChatColor.DARK_GRAY));
+        Common.tell(sender, ChatUtil.center( ChatColor.GRAY + "PAGE " + ChatColor.YELLOW + page + ChatColor.GRAY + " OF " + ChatColor.YELLOW + pages + ChatColor.DARK_GRAY, '='));
 
     }
 }

--- a/src/main/java/me/emiljimenez21/virtualshop/database/types/SQLiteDatabase.java
+++ b/src/main/java/me/emiljimenez21/virtualshop/database/types/SQLiteDatabase.java
@@ -11,8 +11,9 @@ public class SQLiteDatabase extends PluginQueries {
 
     public SQLiteDatabase() {
         try {
+             Class.forName("org.sqlite.JDBC");
             this.connection = DriverManager.getConnection("jdbc:sqlite:" + Virtualshop.getInstance().getDataFolder() +  "/shop.db");
-        } catch (SQLException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
         init();

--- a/src/main/resources/settings.yml
+++ b/src/main/resources/settings.yml
@@ -11,3 +11,5 @@ mysql:
   pass: "password"
   name: "minecraft"
   prefix: "shop_"
+
+Command_Aliases: [virturalshop, vs]


### PR DESCRIPTION
The functionality is ok, but the commands may cause internal errors due to the requirement of the Foundation package. Close #11 and support papermc 1.17.1.

Major changes:
1. maven package updates and clean up, the old file makes a 50MB jar because nothing is excluded or included.
2. Sqlite JDBC fix, if we don't load it explicitly it cannot find the driver.
3. Other Minor API changes.

I am just fixing Java problems and not very familiar with MC plugin configs.  I also moved all commands into subcommand but it still needs some fixes for the commands. Maybe I should merge a 1.17 modification only version.